### PR TITLE
Fix FCS on 8821cu

### DIFF
--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3993,8 +3993,17 @@ static sint fill_radiotap_hdr(_adapter *padapter, union recv_frame *precvframe, 
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FRAG;
 
 	/* always append FCS */
-	hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
+	//hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
 
+#ifdef CONFIG_RX_PACKET_APPEND_FCS
+        // Start by always indicating FCS is there:
+        hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_FCS;
+
+        // Next, test for prior conditions that will remove FCS, and update flag accordingly:
+        if(check_fwstate(&padapter->mlmepriv,WIFI_MONITOR_STATE) == _FALSE)
+                if((pattrib->pkt_rpt_type == NORMAL_RX) && (pHalData->ReceiveConfig & RCR_APPFCS))
+                        hdr_buf[rt_len] &= ~IEEE80211_RADIOTAP_F_FCS;
+#endif
 
 	if (0)
 		hdr_buf[rt_len] |= IEEE80211_RADIOTAP_F_DATAPAD;

--- a/hal/rtl8821c/usb/rtl8821cu_recv.c
+++ b/hal/rtl8821c/usb/rtl8821cu_recv.c
@@ -38,7 +38,8 @@ static u8 recvbuf2recvframe_proccess_normal_rx
 
 #ifdef CONFIG_RX_PACKET_APPEND_FCS
 	if (check_fwstate(&padapter->mlmepriv, WIFI_MONITOR_STATE) == _FALSE) {
-		if (rtl8821c_rx_fcs_appended(padapter))
+		//if (rtl8821c_rx_fcs_appended(padapter))
+		if ((pattrib->pkt_rpt_type == NORMAL_RX) && (pHalData->ReceiveConfig & RCR_APPFCS))
 			pattrib->pkt_len -= IEEE80211_FCS_LEN;
 	}
 #endif


### PR DESCRIPTION
Issue also exist on 8821cu as described and fixed for 8812au at
https://github.com/aircrack-ng/rtl8812au/issues/28
https://github.com/j-forristal/rtl8812au/commit/14109ecfdbb4e02b2cb60cc045b17cdd108fee92

aircrack-ng now unable to capture wpa handshake while driver is in monitor mode. 