### PR TITLE
issue #92: don't require floor() and ceil() functions

### DIFF
--- a/core/rtw_mp.c
+++ b/core/rtw_mp.c
@@ -23,19 +23,16 @@
 	#include <rtw_bt_mp.h>
 #endif
 
-#ifdef CONFIG_MP_VHT_HW_TX_MODE
-#define CEILING_POS(X) ((X - (int)(X)) > 0 ? (int)(X + 1) : (int)(X))
-#define CEILING_NEG(X) ((X - (int)(X)) < 0 ? (int)(X - 1) : (int)(X))
-#define ceil(X) (((X) > 0) ? CEILING_POS(X) : CEILING_NEG(X))
 
-int rtfloor(float x)
-{
-	int i = x - 2;
-	while
-	(++i <= x - 1)
-		;
-	return i;
-}
+#ifdef CONFIG_MP_VHT_HW_TX_MODE
+#define CEILING_POS(X) (((X) - (int)(X)) != 0.0 ? (int)(X) + 1 : (int)(X))
+#define CEILING_NEG(X) ((int)(X))
+#define ceil(X) (((X) >= 0.0) ? CEILING_POS(X) : CEILING_NEG(X))
+
+#define FLOOR_POS(X) ((int)(X))
+#define FLOOR_NEG(X) (((X) - (int)(X)) != 0.0 ? (int)(X) - 1 : (int)(X))
+#define floor(X) (((X) >= 0.0) ? FLOOR_POS(X) : FLOOR_NEG(X))
+#define rtfloor(X) floor(X)
 #endif
 
 #ifdef CONFIG_MP_INCLUDED

--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1024,13 +1024,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
 #define IEEE80211_DELBA_PARAM_TID_MASK 0xF000
 #define IEEE80211_DELBA_PARAM_INITIATOR_MASK 0x0800
 
-/*
- * A-PMDU buffer sizes
- * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
- */
-#define IEEE80211_MIN_AMPDU_BUF 0x8
-#define IEEE80211_MAX_AMPDU_BUF 0x40
-
 
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0


### PR DESCRIPTION
Since these are trivial functions implemented as macros and using integer conversion, did that.

Note that we correct the value of the ceil() function for negative values (i.e. while the ceil(-5.0) == -5.0, the ceil(-5.1) == -5.0 also, and not -6.0 as was being returned).

Unless you wanted `sign(x) * ceil(abs(x))` which is something else entirely.
