### PR TITLE
issue #96: remove conflicting definitions for IEEE80211_MAX_AMPDU_BUF

### DIFF
--- a/include/wifi.h
+++ b/include/wifi.h
@@ -1024,14 +1024,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
 #define IEEE80211_DELBA_PARAM_TID_MASK 0xF000
 #define IEEE80211_DELBA_PARAM_INITIATOR_MASK 0x0800
 
-/*
- * A-PMDU buffer sizes
- * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
- */
-#define IEEE80211_MIN_AMPDU_BUF 0x8
-#define IEEE80211_MAX_AMPDU_BUF 0x40
-
-
 /* Spatial Multiplexing Power Save Modes */
 #define WLAN_HT_CAP_SM_PS_STATIC		0
 #define WLAN_HT_CAP_SM_PS_DYNAMIC	1


### PR DESCRIPTION
The symbols IEEE80211_MAX_AMPDU_BUF and IEEE80211_MIN_AMPDU_BUF aren't used in the source, and further more conflict with the definitions in <linux/ieee80211.h>.

Signed-off-by: Philip Prindeville <philipp@redfish-solutions.com>