### PR TITLE
Force LF line endings for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Thanks for the project, I needed it to fix my adapter.

I got a bit annoyed though because I cloned the repo on Windows (Since my distro had no working wifi and I cant use ethernet) and git decided to normalize the line endings to CRLF, which can be a pain to fix. This also created errors when I tried to run the install script.

This should help out my fellow Windows users from accidentally making the same mistake.